### PR TITLE
Add Missing Argument for InvalidRequestError When Composing API Path

### DIFF
--- a/lib/checkr/api_class.rb
+++ b/lib/checkr/api_class.rb
@@ -369,7 +369,7 @@ module Checkr
         end
 
         unless missing.empty?
-          raise InvalidRequestError.new("Could not determine the full URL to request. Missing the following values: #{missing.to_a.join(', ')}.")
+          raise InvalidRequestError.new("Could not determine the full URL to request. Missing the following values: #{missing.to_a.join(', ')}.", "url")
         end
       end
       ret


### PR DESCRIPTION
In `Checkr::APIClass.compose_api_path`, if there are missing arguments for building the API path an `InvalidRequestError` is raised with a single argument when at least 2 are expected. This causes a generic `ArgumentError` to get thrown masking the expected exception.