### PR TITLE
Add Candidate#save method.

### DIFF
--- a/lib/checkr/candidate.rb
+++ b/lib/checkr/candidate.rb
@@ -26,6 +26,8 @@ module Checkr
     api_class_method :create, :post
     api_class_method :retrieve, :get, ":path/:id", :arguments => [:id]
 
+    api_instance_method :save, :post, :default_params => :changed_attributes
+
     def self.path
       "/v1/candidates"
     end

--- a/samples/candidate.md
+++ b/samples/candidate.md
@@ -139,6 +139,57 @@ candidate = Checkr::Candidate.retrieve("e44aa283528e6fde7d542194")
 ```
 
 
+## Update an existing Candidate
+
+### Definition
+
+```ruby
+candidate = Checkr::Candidate.retrieve({CANDIDATE_ID})
+candidate.copy_requested = {BOOL}
+candidate.save
+```
+
+### Example Request
+
+```ruby
+require 'checkr' # Note the gem is named checkr-official
+Checkr.api_key = "83ebeabdec09f6670863766f792ead24d61fe3f9"
+
+candidate = Checkr::Candidate.retrieve("e44aa283528e6fde7d542194")
+candidate.copy_requested = true
+candidate.save
+```
+
+### Example Response
+
+```ruby
+#<Checkr::Candidate:0x3fd909a22584 id=e44aa283528e6fde7d542194> JSON: {
+  "first_name": "John",
+  "middle_name": "Alfred",
+  "last_name": "Smith",
+  "email": "john.smith@gmail.com",
+  "phone": null,
+  "zipcode": "90401",
+  "dob": "1970-01-22",
+  "ssn": "XXX-XX-4645",
+  "driver_license_number": "F211165",
+  "driver_license_state": "CA",
+  "previous_driver_license_number": null,
+  "previous_driver_license_state": null,
+  "copy_requested": true,
+  "custom_id": null,
+  "reports": {"object":"list","data":[{"id":"4722c07dd9a10c3985ae432a"}, ...]},
+  "geos": {"object":"list","data":[]},
+  "adjudication": null,
+  "documents": {"object":"list","data":[]},
+  "id": "e44aa283528e6fde7d542194",
+  "object": "test_candidate",
+  "uri": "/v1/candidates/e44aa283528e6fde7d542194",
+  "created_at": "2014-06-17T05:55:47Z"
+}
+```
+
+
 ## List existing Candidates
 
 ### Definition

--- a/test/checkr/candidate_test.rb
+++ b/test/checkr/candidate_test.rb
@@ -41,6 +41,19 @@ module Checkr
         assert_equal(test_candidate[:email], candidate.email)
       end
 
+      should 'be updateable' do
+        candidate = Candidate.new(test_candidate)
+        candidate.copy_requested = true
+
+        @mock.expects(:post).once.with do |url, headers, params|
+          params == candidate.changed_attributes && url == "#{@candidate_url}/#{candidate.id}"
+        end.returns(test_response(test_candidate))
+
+        # This should update this instance with test_candidate since it was returned
+        candidate.save
+        assert_equal(test_candidate[:copy_requested], candidate.copy_requested)
+      end
+
       should 'include an empty documents list' do
         # TODO(joncalhoun): Implement this when test docs are available.
 


### PR DESCRIPTION
Why:

* In the required flow for checkr conformance the information for a
  candidate is gathered before the copy_requested value is recieved on
  the authorize page. This update would allow users of the API to create
  a candidate, then update the candidate **if** the candidate chooses
  they would like to request a copy on the authorization form.

This change addresses the need by:

* Add api instance method :save to the candidate class.
* Add tests for the Candidate#save method.
* Add sample for the Candidate#save method.