### PR TITLE
Add Documents to Report

### DIFF
--- a/lib/checkr/report.rb
+++ b/lib/checkr/report.rb
@@ -31,6 +31,8 @@ module Checkr
     attribute :motor_vehicle_report, :MotorVehicleReport
     attribute_writer_alias :motor_vehicle_report_id, :motor_vehicle_report
 
+    attribute :documents, APIList.constructor(:Document)
+    attribute_writer_alias :document_ids, :documents
 
     api_class_method :retrieve, :get, ":path/:id", :arguments => [:id]
     api_class_method :create, :post

--- a/test/checkr/report_test.rb
+++ b/test/checkr/report_test.rb
@@ -113,9 +113,9 @@ module Checkr
         assert(@report.county_criminal_searches.is_a?(APIList))
       end
 
-      should 'have the documents attribute' do
-          assert_equal(test_report[:document_ids], @report.documents.json)
-          assert(@report.documents.is_a?(APIList))
+      should "have the documents attribute" do
+        assert_equal(test_report[:document_ids], @report.documents.json)
+        assert(@report.documents.is_a?(APIList))
       end
 
       should 'have the motor_vehicle_report_id attribute' do

--- a/test/checkr/report_test.rb
+++ b/test/checkr/report_test.rb
@@ -113,6 +113,11 @@ module Checkr
         assert(@report.county_criminal_searches.is_a?(APIList))
       end
 
+      should 'have the documents attribute' do
+          assert_equal(test_report[:document_ids], @report.documents.json)
+          assert(@report.documents.is_a?(APIList))
+      end
+
       should 'have the motor_vehicle_report_id attribute' do
         assert_equal(test_report[:motor_vehicle_report_id], @report.motor_vehicle_report.id)
         assert(@report.motor_vehicle_report.is_a?(MotorVehicleReport))

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -88,7 +88,10 @@ module Checkr
        :county_criminal_search_ids=>
         ["539fdcf335644a0ef4000001", "532e71cfe88a1d4e8d00000i"],
        :motor_vehicle_report_id=>"539fd88c101897f7cd000007",
-     	 :eviction_search_id=>"539fd88c101897f7cd000008"}
+       :eviction_search_id=>"539fd88c101897f7cd000008",
+       :document_ids=>
+        ["4722c07dd9a10c3985ae432a"]
+       }
     end
 
     def test_report_list

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -89,8 +89,7 @@ module Checkr
         ["539fdcf335644a0ef4000001", "532e71cfe88a1d4e8d00000i"],
        :motor_vehicle_report_id=>"539fd88c101897f7cd000007",
        :eviction_search_id=>"539fd88c101897f7cd000008",
-       :document_ids=>
-        ["4722c07dd9a10c3985ae432a"]
+       :document_ids => ["4722c07dd9a10c3985ae432a"]
        }
     end
 


### PR DESCRIPTION
Add `documents` and `document_ids` accessors to the `Report` object. 