### PR TITLE
add no middle name attribute to candidate object

### DIFF
--- a/lib/checkr/candidate.rb
+++ b/lib/checkr/candidate.rb
@@ -3,6 +3,7 @@ module Checkr
 
     attribute :first_name
     attribute :middle_name
+    attribute :no_middle_name
     attribute :last_name
     attribute :email
     attribute :phone


### PR DESCRIPTION
### Add Middle Name Attribute to Candidate Object
This is necessary because we have cases where we have already created candidates in Checkr, but those candidates have not completed their application process. These candidates are old and come from a time before we were collecting middle names and posting them to Checkr when creating the candidate. 

Now, when attempting to create a report, these candidates experience a validation error on Checkr's end, since the `no_middle_name` attribute is not set properly. This can be fixed in a rails console if this attribute is placed on the object. That way we can update the `no_middle_name` attribute and the report will process.