### PR TITLE
Add Subscription.all

### DIFF
--- a/lib/checkr/subscription.rb
+++ b/lib/checkr/subscription.rb
@@ -13,6 +13,7 @@ module Checkr
     attribute :candidate, :Candidate
     attribute_writer_alias :candidate_id, :candidate
 
+    api_class_method :all, :get, :constructor => APIList.constructor(:Subscription)
     api_class_method :retrieve, :get, ":path/:id", :arguments => [:id]
     api_class_method :create, :post
 

--- a/test/checkr/subscription_test.rb
+++ b/test/checkr/subscription_test.rb
@@ -20,6 +20,17 @@ module Checkr
         assert(subscription.is_a?(Subscription))
         assert_equal(test_subscription[:id], subscription.id)
       end
+
+      should 'be listable' do
+        @mock.expects(:get).once.returns(test_response(test_subscription_list))
+
+        subscriptions = Subscription.all
+
+        assert(subscriptions.is_a?(APIList))
+        subscriptions.each do |subscription|
+          assert(subscription.is_a?(Subscription))
+        end
+      end
     end
 
     context 'Subscription instance' do

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -116,6 +116,13 @@ module Checkr
        :candidate_id=>"e44aa283528e6fde7d542194"}
     end
 
+    def test_subscription_list
+      {
+        :object => 'list',
+        :data => [test_subscription, test_subscription, test_subscription]
+      }
+    end
+
     def test_geo
       {:id=>"e44aa283528e6fde7d542194",
        :object=>"geo",


### PR DESCRIPTION
Subscription.all isn't documented at https://docs.checkr.com/#subscription but I found the endpoint does exist and works as expected.
