### PR TITLE
Relax rest-client version constraints

### DIFF
--- a/checkr-official.gemspec
+++ b/checkr-official.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('rest-client', '>= 1.4', '< 3.0')
   s.add_dependency('mime-types', '>= 1.25', '< 3.0')
   s.add_dependency('json', '~> 1.8.1')
 
@@ -28,4 +28,3 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 end
-


### PR DESCRIPTION
rest-client version 2.0 was released recently: rest-client/rest-client@3a79728

Per the [upgrade notes](https://github.com/rest-client/rest-client/commit/51032140c9de747520278f1834156134944eb61b) and [history](https://github.com/rest-client/rest-client/blob/master/history.md#200), version 2.x is largely compatible API with version 1.x. This allows users of this gem to upgrade to rest-client version 2.0.