### PR TITLE
Remove mime-types dependency

### DIFF
--- a/checkr-official.gemspec
+++ b/checkr-official.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency('rest-client', '>= 1.4', '< 3.0')
-  s.add_dependency('mime-types', '>= 1.25', '< 3.0')
   s.add_dependency('json', '~> 1.8.1')
 
   s.add_development_dependency('mocha', '~> 0.13.2')


### PR DESCRIPTION
Hey! Thanks for merging https://github.com/checkr/checkr-ruby/pull/26. 

I'm now trying to upgrade my app to mime-types v3.x. `mime-types` is a dependency of `rest-client`, and I can't find anything in this gem that is using the `mime-types` dependency directly. This removes the dependency and lets users defer to `rest-client` for the proper version of mime-types.