### PR TITLE
Add `type` to `Document` resource

### DIFF
--- a/lib/checkr/document.rb
+++ b/lib/checkr/document.rb
@@ -5,6 +5,7 @@ module Checkr
     attribute :filesize
     attribute :filename
     attribute :content_type
+    attribute :type
 
     api_class_method :all, :get, "/v1/candidates/:candidate_id/documents", :constructor => :DocumentList
     api_class_method :create, :post, "/v1/candidates/:candidate_id/documents"

--- a/test/checkr/document_test.rb
+++ b/test/checkr/document_test.rb
@@ -84,6 +84,10 @@ module Checkr
         assert_equal(test_document[:content_type], @document.content_type)
       end
 
+      should 'have the type attribute' do
+        assert_equal(test_document[:type], @document.type)
+      end
+
     end
 
     should 'be registered' do

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -408,6 +408,7 @@ module Checkr
        :download_uri=>"https://checkr-documents.checkr.com/download_path",
        :filesize=>8576,
        :filename=>"1423684910_candidate_driver_license.jpg",
+       :type=>"driver_license",
        :content_type=>"image/jpeg"}
     end
     def test_document_list


### PR DESCRIPTION
Surfaces `type` attribute specified in [documentation](http://docs.checkr.com/#document).