### PR TITLE
Allow update to candidate geos

### DIFF
--- a/lib/checkr/candidate.rb
+++ b/lib/checkr/candidate.rb
@@ -18,8 +18,7 @@ module Checkr
     attribute :custom_id
     attribute :reports, :ReportList, :nested => true
     attribute_writer_alias :report_ids, :reports
-    attribute :geos, APIList.constructor(:Geo)
-    attribute_writer_alias :geo_ids, :geos
+    attribute :geo_ids
     attribute :documents, :DocumentList, :nested => true, :default => {}
     attribute_writer_alias :document_ids, :documents
 
@@ -28,6 +27,10 @@ module Checkr
     api_class_method :retrieve, :get, ":path/:id", :arguments => [:id]
 
     api_instance_method :save, :post, :default_params => :changed_attributes
+
+    def geos
+      APIList.constructor(:Geo).call(geo_ids)
+    end
 
     def self.path
       "/v1/candidates"

--- a/test/checkr/candidate_test.rb
+++ b/test/checkr/candidate_test.rb
@@ -43,7 +43,10 @@ module Checkr
 
       should 'be updateable' do
         candidate = Candidate.new(test_candidate)
+        candidate.geo_ids = ['test']
         candidate.copy_requested = true
+
+        assert_equal(candidate.changed_attributes, copy_requested: true, geo_ids: ['test'])
 
         @mock.expects(:post).once.with do |url, headers, params|
           params == candidate.changed_attributes && url == "#{@candidate_url}/#{candidate.id}"


### PR DESCRIPTION
Change `Candidate` resource to support posting of `geo_ids` when updated.