### PR TITLE
Make api_key/api_base Thread Safe

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,11 @@
-## v1.5.0 (2018-02-2)
+## v1.5.1 (2018-03-26)
+
+Fixes:
+
+- Make thread safe `api_key` and `api_base` configuration
+
+
+## v1.5.0 (2018-02-02)
 
 Features:
 

--- a/checkr-official.gemspec
+++ b/checkr-official.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.summary = 'Ruby bindings for Checkr API'
   s.description = 'Checkr - Automated background screenings and driving records. See https://checkr.com/ for details.'
   s.homepage = 'https://checkr.com/'
-  s.authors = ['Jon Calhoun']
-  s.email = ['joncalhoun@gmail.com']
+  s.authors = ['Checkr Engineering', 'Jon Calhoun']
+  s.email = ['eng@checkr.com', 'joncalhoun@gmail.com']
   s.version = Checkr::VERSION
 
   s.required_ruby_version = '>= 1.9.3'
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('mocha', '~> 0.13.2')
   s.add_development_dependency('shoulda', '~> 3.4.0')
-  s.add_development_dependency('activesupport', '~> 4.2.6')
   s.add_development_dependency('bump', '0.5.2')
   s.add_development_dependency('rake', '10.4.2')
+  s.add_development_dependency('activesupport', '~> 4.2')
   s.add_development_dependency('test-unit')
 
   s.files = `git ls-files`.split("\n")

--- a/lib/checkr.rb
+++ b/lib/checkr.rb
@@ -46,15 +46,34 @@ require 'checkr/errors/invalid_request_error'
 require 'checkr/errors/authentication_error'
 
 module Checkr
-  @api_base = "https://api.checkr.com"
-  @api_key = nil
+  @api_base = 'https://api.checkr.com'.freeze
+  @main_thread = nil
 
-  class << self
-    attr_accessor :api_key, :api_base, :api_test
+  def self.main_thread
+    @main_thread ||= Thread.current
+  end
+
+  # Inspired by ActiveSupport #thread_mattr_accessor
+
+  def self.api_key
+    Thread.current['attr_Checkr_api_key'] || @main_thread['attr_Checkr_api_key']
+  end
+
+  def self.api_key=(key)
+    main_thread['attr_Checkr_api_key'] = key if main_thread == Thread.current
+    Thread.current['attr_Checkr_api_key'] = key
+  end
+
+  def self.api_base
+    Thread.current['attr_Checkr_api_base'] || @api_base
+  end
+
+  def self.api_base=(base)
+    Thread.current['attr_Checkr_api_base'] = base
   end
 
   def self.api_url(path='')
-    "#{@api_base}#{path}"
+    "#{api_base}#{path}"
   end
 
   def self.request(method, path, params={}, headers={})

--- a/lib/checkr/version.rb
+++ b/lib/checkr/version.rb
@@ -1,3 +1,3 @@
 module Checkr
-  VERSION = '1.5.0'.freeze
+  VERSION = '1.5.1'.freeze
 end

--- a/test/checkr/thread_safe_test.rb
+++ b/test/checkr/thread_safe_test.rb
@@ -1,0 +1,78 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Checkr
+  class ThreadSafeTest < Test::Unit::TestCase
+
+    def before_test
+      @output = ["[Main thread] #{::Checkr.api_key}"]
+
+      Thread.new do
+        @output << "[Thread 1] #{::Checkr.api_key}"
+        ::Checkr.api_key = 'changed by thread 1'
+        sleep 0.05
+        @output << "[Thread 1] #{::Checkr.api_key}"
+      end
+
+      Thread.new do
+        sleep 0.05
+        @output << "[Thread 2] #{::Checkr.api_key}"
+        ::Checkr.api_key = 'changed by thread 2'
+        @output << "[Thread 2] #{::Checkr.api_key}"
+        sleep 0.2
+        @output << "[Thread 2] #{::Checkr.api_key}"
+      end
+
+      Thread.new do
+        sleep 0.25
+        @output << "[Thread 3] #{::Checkr.api_key}"
+      end
+
+      sleep 0.1
+
+      @output << "[Main thread] #{::Checkr.api_key}"
+
+      sleep 0.05
+
+      ::Checkr.api_key = 'changed by main thread'
+      @output << "[Main thread] #{::Checkr.api_key}"
+      sleep 0.2
+    end
+
+    should 'be defined on main thread' do
+      assert_true(@output.include?('[Main thread] foo'))
+    end
+
+    should 'fall back to main thread withing a child thread' do
+      assert_true(@output.include?('[Thread 1] foo'))
+    end
+
+    should 'not be changed by thread 1 in main thread' do
+      assert_false(@output.include?('[Main thread] changed by thread 1'))
+    end
+
+    should 'not be changed by thread 2 in main thread' do
+      assert_false(@output.include?('[Main thread] changed by thread 2'))
+    end
+
+    should 'be changeable by main thread' do
+      assert_true(@output.include?('[Main thread] changed by main thread'))
+    end
+
+    should 'not change child thread if changed in main thread' do
+      assert_false(@output.include?('[Thread 2] changed by main thread'))
+    end
+
+    should 'be changeable within thread 1' do
+      assert_true(@output.include?('[Thread 1] changed by thread 1'))
+    end
+
+    should 'be changeable within thread 2' do
+      assert_true(@output.include?('[Thread 2] changed by thread 2'))
+    end
+
+    should 'bubble down to thread 3 if changed in main and not defined on thread' do
+      assert_true(@output.include?('[Thread 3] changed by main thread'))
+    end
+
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,9 +34,11 @@ class Test::Unit::TestCase
     @mock = mock
     Checkr.mock_rest_client = @mock
     Checkr.api_key="foo"
+    before_test if respond_to?(:before_test)
   end
 
   teardown do
+    after_test if respond_to?(:after_test)
     Checkr.mock_rest_client = nil
     Checkr.api_key=nil
   end


### PR DESCRIPTION
Currently, the gem is working well with project using only one Api Key, but if the app had to manage multiple customers, and thus for, update `Checkr.api_key` it would not work properly.

Consider this scenario: we use a web server like `puma` who handles different requests by threads (sharing same process), and that each request is setting the `api_key` then if two requests come at the same time, operations happening within request action using the API might use the wrong `api_key` depending of the order of operations executed in the two different threads.

This PR addresses that issue by using `Thread.current#[]` the same way [ActiveSupport implements `thread_mattr_accessor`](https://github.com/rails/rails/blob/20c91119903f70eb19aed33fe78417789dbf070f/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb). I didn't use `thread_mattr_accessor` as it's not handling the "fall back to main thread" case.

Consider this test:

```ruby
require 'checkr'

::Checkr.api_key = 'original key'

puts 'Thread test:'

puts "[Main thread] Key #{::Checkr.api_key}"

Thread.new do
  puts "[Thread 1] Key #{::Checkr.api_key}"
  ::Checkr.api_key = 'changed by thread 1'
  sleep 2
  puts "[Thread 1] Key #{::Checkr.api_key}"
end

Thread.new do
  sleep 2
  puts "[Thread 2] Key #{::Checkr.api_key}"
  ::Checkr.api_key = 'changed by thread 2'
  puts "[Thread 2] Key #{::Checkr.api_key}"
  sleep 2
  puts "[Thread 2] Key #{::Checkr.api_key}"
end

Thread.new do
  puts "[Thread 3] Key #{::Checkr.api_key}"
  sleep 3
  puts "[Thread 3] Key #{::Checkr.api_key}"
end

sleep 2

puts "[Main thread] Key #{::Checkr.api_key}"

::Checkr.api_key = 'changed by main thread'

sleep 0.5

puts "[Main thread] Key #{::Checkr.api_key}"

sleep 2
```

Current results:
```
Thread test:
[Main thread] Key original key
[Thread 1] Key original key
[Thread 3] Key changed by thread 1
[Thread 1] Key changed by thread 1
[Main thread] Key changed by thread 1
[Thread 2] Key changed by thread 1
[Thread 2] Key changed by thread 2
[Main thread] Key changed by thread 2
[Thread 3] Key changed by thread 2
[Thread 2] Key changed by thread 2
```

A given thread should not see a key defined by another thread, like on the line `[Thread 2] Key modified by thread 1` or `[Main thread] Key modified by thread 2`

Results with this PR applied:
```Thread test:
Thread test:
[Main thread] Key original key
[Thread 1] Key original key
[Thread 3] Key original key
[Main thread] Key original key
[Thread 1] Key changed by thread 1
[Thread 2] Key original key
[Thread 2] Key changed by thread 2
[Main thread] Key changed by main thread
[Thread 3] Key changed by main thread
[Thread 2] Key changed by thread 2
```