### PR TITLE
Add License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2018 Checkr, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/checkr-official.gemspec
+++ b/checkr-official.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.authors = ['Checkr Engineering Team']
   s.email = ['eng@checkr.com']
   s.version = Checkr::VERSION
+  s.license = 'Apache-2.0'
 
   s.required_ruby_version = '>= 1.9.3'
 


### PR DESCRIPTION
Add the Apache 2.0 License, to reflect our policy on Open-Source projects.