### PR TITLE
Add Geos to Report

### DIFF
--- a/lib/checkr/report.rb
+++ b/lib/checkr/report.rb
@@ -41,6 +41,9 @@ module Checkr
     attribute :documents, APIList.constructor(:Document)
     attribute_writer_alias :document_ids, :documents
 
+    attribute :geos, APIList.constructor(:Geo)
+    attribute_writer_alias :geo_ids, :geos
+
     attribute :verifications, :VerificationList, :nested => true, :default => {}
     attribute_writer_alias :verification_ids, :verifications
 

--- a/lib/checkr/report.rb
+++ b/lib/checkr/report.rb
@@ -41,7 +41,7 @@ module Checkr
     attribute :documents, APIList.constructor(:Document)
     attribute_writer_alias :document_ids, :documents
 
-    attribute :geos, APIList.constructor(:Geo)
+    attribute :geos, APIList.constructor(:Geo), :default => {}
     attribute_writer_alias :geo_ids, :geos
 
     attribute :verifications, :VerificationList, :nested => true, :default => {}

--- a/test/checkr/report_test.rb
+++ b/test/checkr/report_test.rb
@@ -122,6 +122,11 @@ module Checkr
         assert(@report.documents.is_a?(APIList))
       end
 
+      should "have the geos attribute" do
+        assert_equal(test_report[:geo_ids], @report.geos.json)
+        assert(@report.geos.is_a?(APIList))
+      end
+
       should 'have the motor_vehicle_report_id attribute' do
         assert_equal(test_report[:motor_vehicle_report_id], @report.motor_vehicle_report.id)
         assert(@report.motor_vehicle_report.is_a?(MotorVehicleReport))

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -91,7 +91,8 @@ module Checkr
         ["539fdcf335644a0ef4000001", "532e71cfe88a1d4e8d00000i"],
        :motor_vehicle_report_id=>"539fd88c101897f7cd000007",
        :eviction_search_id=>"539fd88c101897f7cd000008",
-       :document_ids => ["4722c07dd9a10c3985ae432a"]
+       :document_ids => ["4722c07dd9a10c3985ae432a"],
+       :geo_ids => ["e44aa283528e6fde7d542194"]
        }
     end
 


### PR DESCRIPTION
Adds geos to the report object. This is supported per the checkr docs, but isn't currently supported in this gem.