### PR TITLE
Allow passing API key in individual calls

### DIFF
--- a/lib/checkr.rb
+++ b/lib/checkr.rb
@@ -61,6 +61,8 @@ module Checkr
   end
 
   def self.request(method, path, params={}, headers={})
+    api_key = headers.key?(:api_key) ? headers.delete(:api_key) : @api_key
+
     verify_api_key(api_key)
 
     url = api_url(path)


### PR DESCRIPTION
Allow passing of API for individual calls in order to allow for thread safe usage of multiple API keys.