### PR TITLE
bugfix: candidate_id should be a string

### DIFF
--- a/lib/checkr/report.rb
+++ b/lib/checkr/report.rb
@@ -8,10 +8,10 @@ module Checkr
     attribute :turnaround_time
     attribute :package
     attribute :values
+    attribute :candidate_id
     attribute :candidate, :Candidate
-    attribute_writer_alias :candidate_id, :candidate
 
-    attribute :adverse_items, :AdverseItemList, :nested => true, :default => {}
+    attribute :adverse_items, :AdverseItemList, nested: true, default: {}
     attribute_writer_alias :adverse_item_ids, :adverse_items
 
     attribute :ssn_trace, :SSNTrace
@@ -47,10 +47,10 @@ module Checkr
     attribute :documents, APIList.constructor(:Document)
     attribute_writer_alias :document_ids, :documents
 
-    attribute :geos, APIList.constructor(:Geo), :default => {}
+    attribute :geos, APIList.constructor(:Geo), default: {}
     attribute_writer_alias :geo_ids, :geos
 
-    attribute :verifications, :VerificationList, :nested => true, :default => {}
+    attribute :verifications, :VerificationList, nested: true, default: {}
     attribute_writer_alias :verification_ids, :verifications
 
     attribute :education_verification, :EducationVerification
@@ -59,15 +59,16 @@ module Checkr
     attribute :employment_verification, :EmploymentVerification
     attribute_writer_alias :employment_verification_id, :employment_verification
 
-    api_class_method :retrieve, :get, ":path/:id", :arguments => [:id]
+    api_class_method :retrieve, :get, ':path/:id', arguments: [:id]
     api_class_method :create, :post
 
-    api_instance_method :save, :post, :default_params => :changed_attributes
+    api_instance_method :save, :post, default_params: :changed_attributes
 
     def self.path
-      "/v1/reports"
+      '/v1/reports'
     end
 
-    APIClass.register_subclass(self, "report")
+    APIClass.register_subclass(self, 'report')
+
   end
 end


### PR DESCRIPTION
## Problem:

when retrieving the report, the candidate is a JSON object. alias method
can't delegate `candidate_id` to the candidate object.

Here is the snapshot of the error.

![image](https://user-images.githubusercontent.com/1224077/182084839-623c7457-dc15-4dee-82ba-385685ab820a.png)


## Changes

explicitly define the method to access the candidate_id

