### PR TITLE
bugfix: `+` takes precedence over `ternary operator`

### DIFF
--- a/lib/checkr.rb
+++ b/lib/checkr.rb
@@ -77,7 +77,8 @@ module Checkr
 
     if [:get, :head, :delete].include?(method.to_s.downcase.to_sym)
       unless params.empty?
-        url += URI.parse(url).query ? '&' : '?' + Util.query_string(params)
+        url += URI.parse(url).query ? '&' : '?'
+        url += Util.query_string(params)
       end
       params = nil
     end


### PR DESCRIPTION
## Problem

when the base URL contains parameters, the params argument will be ignored.

![image](https://user-images.githubusercontent.com/1224077/187159970-52b633c0-5c61-403c-becc-1fd987304b1f.png)

## How to reproduce?

```
URL: https://api.checkr-staging.com/v1/nodes?include=packages
parameter: {page: 2}
```

## Root cause

Ruby operator `+` takes precedence over `? :`, when URI.parse returns true, only `&` will be returned.

```
 url += URI.parse(url).query ? '&' : '?' + Util.query_string(params)
```

Here is the execution plan

```
 url += if URI.parse(url).query 
  '&' 
 else
'?' + Util.query_string(params)
```

## How to fix it?

solution 1: use the parenthesis to correct the precedence.

```
 url += (URI.parse(url).query ? '&' : '?') + Util.query_string(params)
```

solution2: change the code to two lines.


## Changes

in this PR, we use solution2 to fix the bug.
