### PR TITLE
enhancement: error.message should return a string.

### DIFF
--- a/lib/checkr/errors/checkr_error.rb
+++ b/lib/checkr/errors/checkr_error.rb
@@ -6,7 +6,7 @@ module Checkr
     attr_reader :json_body
 
     def initialize(message=nil, http_status=nil, http_body=nil, json_body=nil)
-      @message = message
+      @message = message.to_s
       @http_status = http_status
       @http_body = http_body
       @json_body = json_body


### PR DESCRIPTION
## Problem

Sentry is a popular exception monitoring tool for ruby, but it fails to
capture the error raised by checkr ruby gem.

After some investigation, I found the checkr sometime set an array to
the exception message.

Here is an example

```
exception.message
=> ["First name must only contain letters, numbers, spaces, hyphens, apostrophes, periods, and commas."]
```

Usually, ruby exception's `message` method should return a string as an
abstraction of error and developer save the detail information to
internal instance variable.

## Solution

This PR is to convert the message variable to a string to avoid crashing
the monitoring tool.


## Related PR

Sentry crashes when error message is an array.

https://github.com/getsentry/sentry-ruby/pull/1879